### PR TITLE
[Bug #36] - overflow scroll

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -23,6 +23,10 @@ body {
   right: 0;
 }
 
+body, html {
+  overflow-y: scroll;
+}
+
 .bold {
   font-weight: bold;
 }


### PR DESCRIPTION
Fixes #36 

### Description
Added in the `overflow-y: scroll` to allow the user to scroll for when the body content extends past the actual views height 

###  Screenshot Before Change:
![image](http://cloud.loganarnett.com/2566e69efde7/Screen%252520Recording%2525202018-10-01%252520at%25252001.29%252520PM.gif)
### Screenshot After Change:
![image2](http://cloud.loganarnett.com/5081db3197bb/Screen%252520Recording%2525202018-10-01%252520at%25252001.30%252520PM.gif)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Non Functional Requirement
- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [x] I have performed a self-review of my own code
- [ ] All new and existing tests passed.
- [ ] Documentation

<!-- Thanks For your PR -->
